### PR TITLE
use #declassify operator

### DIFF
--- a/arm-m4/lowram/common/challenge.jinc
+++ b/arm-m4/lowram/common/challenge.jinc
@@ -14,7 +14,8 @@ fn _poly_compress_challenge(
     reg u32 i = 0;
 
     while (ones_seen < 32) {
-        #[declassify] coeff = challenge[i];
+        coeff = challenge[i];
+        #declassify(coeff);
 
         if (coeff != 0) {
             compressed_challenge[output_offset] = i;
@@ -35,7 +36,8 @@ fn _poly_compress_challenge(
     mask = 1;
     signs = 0;
     while (i < N) {
-        #[declassify] coeff = challenge[i];
+        coeff = challenge[i];
+        #declassify(coeff);
 
         if (coeff != 0) {
             compressed_challenge[output_offset] = i;

--- a/arm-m4/lowram/common/hashing.jinc
+++ b/arm-m4/lowram/common/hashing.jinc
@@ -199,7 +199,7 @@ fn _prepare_xof_for_element_of_A(
     state = __add_zero_after_add(state, SEEDBYTES + 2);
     state = __add_block_end(state, SEEDBYTES + 2, SHAKE128_RATE);
 
-    #[declassify] state = state;
+    #declassify(state);
     return state;
 }
 

--- a/arm-m4/lowram/common/keygen.jinc
+++ b/arm-m4/lowram/common/keygen.jinc
@@ -158,5 +158,6 @@ inline fn __keygen_internal(
 
     signing_key[2 * SEEDBYTES : VERIFICATION_KEY_HASH_SIZE] = verification_key_hash;
 
+    () = #unspill(verification_key);
     return verification_key, signing_key;
 }

--- a/arm-m4/lowram/common/poly.jinc
+++ b/arm-m4/lowram/common/poly.jinc
@@ -165,7 +165,8 @@ fn _poly_check_norm(reg ptr u32[N] a, reg u32 B) -> reg u32 {
 
     reg u32 i; i = 0;
     while {
-        #[declassify] t = a[i];
+        t = a[i];
+        #declassify(t);
         t = -t if t <s 0;
 
         i += 1;
@@ -397,7 +398,7 @@ fn _poly_generate_challenge(
 
             b = (32u) state[:u8 pos];
 
-            #[declassify] b = b;
+            #declassify(b);
             pos += 1;
         } (b > j)
 

--- a/arm-m4/lowram/common/sign.jinc
+++ b/arm-m4/lowram/common/sign.jinc
@@ -292,8 +292,8 @@ inline fn __sign_internal(
                             bound = iGAMMA2;
                             check_norm = _poly_check_norm(polynomial0, bound);
                             if (check_norm == 0) {
-                                #[declassify] polynomial0 = polynomial0;
-                                #[declassify] w_compressed = w_compressed;
+                                #declassify(polynomial0);
+                                #declassify(w_compressed);
                                 polynomial0, hints = _poly_make_hint_inplace(polynomial0, w_compressed[row_number *  COMPRESSED_W_ELEMENT_SIZE_WITH_PADDING : COMPRESSED_W_ELEMENT_SIZE_WITH_PADDING]);
 
                                 () = #unspill(total_hints);
@@ -344,6 +344,6 @@ inline fn __sign_internal(
         () = #unspill(sig);
     }
 
-    #[declassify] sig = sig;
+    #declassify(sig);
     return sig, status;
 }

--- a/arm-m4/lowram/common/verify.jinc
+++ b/arm-m4/lowram/common/verify.jinc
@@ -175,7 +175,8 @@ inline fn __verify_internal(
 
                         () = #spill(status);
                         if (status == 0) {
-                            #[declassify] polynomial = _poly_use_hint(polynomial, space_for_1600_bytes.[:u8 0 : MAX_ONES_IN_HINT], number_of_hints);
+                            #declassify(polynomial);
+                            polynomial = _poly_use_hint(polynomial, space_for_1600_bytes.[:u8 0 : MAX_ONES_IN_HINT], number_of_hints);
 
                             w1_element_packed = compressed_w_element[0 : POLYW1_PACKEDBYTES];
                             w1_element_packed = _polyw1_pack(w1_element_packed, polynomial);
@@ -204,7 +205,8 @@ inline fn __verify_internal(
             status = 0;
             while (j < COMMITMENT_HASH_SIZE) {
                 observed = signature.[:u32 j];
-                #[declassify] expected = ptr_to_xof_state.[:u32 j];
+                expected = ptr_to_xof_state.[:u32 j];
+                #declassify(expected);
 
                 observed ^= expected;
                 status |= observed;

--- a/arm-m4/lowram/ml_dsa_44/ml_dsa.jazz
+++ b/arm-m4/lowram/ml_dsa_44/ml_dsa.jazz
@@ -40,7 +40,7 @@ export fn ml_dsa_44_keygen(
 {
     verification_key, signing_key = __keygen_internal(verification_key, signing_key, seed);
 
-    #[declassify] verification_key = verification_key;
+    #declassify(verification_key);
 
     return verification_key, signing_key;
 }

--- a/arm-m4/lowram/ml_dsa_44/rej_sample.jinc
+++ b/arm-m4/lowram/ml_dsa_44/rej_sample.jinc
@@ -40,7 +40,7 @@ inline fn rej_eta(
 ) -> reg ptr u32[N],
      reg u32 
 {
-    #[declassify] t = t;
+    #declassify(t);
     reg u32 n205 = 205;
     if (t < 15) {
         reg u32 aux;

--- a/arm-m4/lowram/ml_dsa_65/ml_dsa.jazz
+++ b/arm-m4/lowram/ml_dsa_65/ml_dsa.jazz
@@ -40,7 +40,7 @@ export fn ml_dsa_65_keygen(
 {
     verification_key, signing_key = __keygen_internal(verification_key, signing_key, seed);
 
-    #[declassify] verification_key = verification_key;
+    #declassify(verification_key);
 
     return verification_key, signing_key;
 }

--- a/arm-m4/lowram/ml_dsa_65/rej_sample.jinc
+++ b/arm-m4/lowram/ml_dsa_65/rej_sample.jinc
@@ -39,7 +39,7 @@ inline fn rej_eta(
         reg u32 t
         ) -> reg ptr u32[N], reg u32
 {
-    #[declassify] t = t;
+    #declassify(t);
     if (t < 9) {
         a[ctr] = __imm_sub_reg(4, t);
         ctr += 1;

--- a/arm-m4/lowram/ml_dsa_87/ml_dsa.jazz
+++ b/arm-m4/lowram/ml_dsa_87/ml_dsa.jazz
@@ -40,7 +40,7 @@ export fn ml_dsa_87_keygen(
 {
     verification_key, signing_key = __keygen_internal(verification_key, signing_key, seed);
 
-    #[declassify] verification_key = verification_key;
+    #declassify(verification_key);
 
     return verification_key, signing_key;
 }

--- a/arm-m4/lowram/ml_dsa_87/rej_sample.jinc
+++ b/arm-m4/lowram/ml_dsa_87/rej_sample.jinc
@@ -40,7 +40,7 @@ inline fn rej_eta(
 ) -> reg ptr u32[N],
      reg u32 
 {
-    #[declassify] t = t;
+    #declassify(t);
     reg u32 n205 = 205;
     if (t < 15) {
         reg u32 aux;

--- a/arm-m4/ref/common/keygen.jinc
+++ b/arm-m4/ref/common/keygen.jinc
@@ -36,7 +36,8 @@ fn _crypto_sign_keypair_seed(
     /***/
 
     reg ptr u8[SEEDBYTES] rho;
-    #[declassify] rho = state[:u8 0:SEEDBYTES];
+    rho = state[:u8 0:SEEDBYTES];
+    () = #declassify(rho);
 
     /* Expand matrix */
     mat = _polyvec_matrix_expand(mat, rho);

--- a/arm-m4/ref/common/poly.jinc
+++ b/arm-m4/ref/common/poly.jinc
@@ -161,7 +161,8 @@ fn _poly_chknorm(reg ptr u32[N] a, reg u32 B) -> reg u32 {
 
     reg u32 i; i = 0;
     while {
-#[declassify] t = a[i];
+        t = a[i];
+        () = #declassify(t);
         t = -t if t <s 0;
 
         i += 1;

--- a/arm-m4/ref/common/sign.jinc
+++ b/arm-m4/ref/common/sign.jinc
@@ -154,7 +154,8 @@ fn _crypto_sign_signature_ctx_seed(
         reg ptr u32[N] cp;
         mat = s_mat;
 
-        #[declassify] rho = s_rho;
+        rho = s_rho;
+        () = #declassify(rho);
         mat = _polyvec_matrix_expand(mat, rho); s_mat = mat;
 
         s1 = s_s1; s1 = _polyvecl_ntt(s1); s_s1 = s1;
@@ -214,7 +215,7 @@ fn _crypto_sign_signature_ctx_seed(
             () = #spill(sig);
             cp = s_cp;
 
-            #[declassify] commitment_hash = commitment_hash;
+            () = #declassify(commitment_hash);
             cp = _poly_challenge(cp, commitment_hash);
             cp = _poly_ntt(cp);
             /* Compute z, reject if it reveals secret */
@@ -265,9 +266,9 @@ fn _crypto_sign_signature_ctx_seed(
                         } else {
                             () = #unspill(sig);
 
-                            #[declassify] h = h;
-                            #[declassify] s_signer_response = s_signer_response;
-                            #[declassify] sig = sig;
+                            () = #declassify(h);
+                            () = #declassify(s_signer_response);
+                            () = #declassify(sig);
 
                             sig = _pack_sig_nocopy(sig, s_signer_response, h);
                             () = #spill(sig);
@@ -281,6 +282,6 @@ fn _crypto_sign_signature_ctx_seed(
         () = #unspill(sig);
     }
 
-    #[declassify] sig = sig;
+    () = #declassify(sig);
     return sig, status;
 }

--- a/arm-m4/ref/common/verify.jinc
+++ b/arm-m4/ref/common/verify.jinc
@@ -122,7 +122,8 @@ fn _crypto_sign_verify_ctx(
                 for i = 0 to COMMITMENT_HASH_SIZE {
                     if (status == 0) {
                         ci = (32u)commitment_hash[i];
-                        #[declassify] c2i = (32u)pstate[:u8 i];
+                        c2i = (32u)pstate[:u8 i];
+                        () = #declassify(c2i);
                         if (ci != c2i) {
                             status = i + 1;
                         }

--- a/arm-m4/ref/ml_dsa_44/ml_dsa.jazz
+++ b/arm-m4/ref/ml_dsa_44/ml_dsa.jazz
@@ -38,7 +38,7 @@ export fn ml_dsa_44_keygen(
 {
     verification_key, signing_key = _crypto_sign_keypair_seed(verification_key, signing_key, seed);
 
-    #[declassify] verification_key = verification_key;
+    () = #declassify(verification_key);
 
     return verification_key, signing_key;
 }

--- a/arm-m4/ref/ml_dsa_44/rej_eta.jinc
+++ b/arm-m4/ref/ml_dsa_44/rej_eta.jinc
@@ -5,7 +5,7 @@ inline fn rej_eta(
 ) -> reg ptr u32[N],
      reg u32 
 {
-    #[declassify] t = t;
+    () = #declassify(t);
     reg u32 n205 = 205;
     if (t < 15) {
         reg u32 aux;

--- a/arm-m4/ref/ml_dsa_44/rounding.jinc
+++ b/arm-m4/ref/ml_dsa_44/rounding.jinc
@@ -99,7 +99,7 @@ inline fn __make_hint(reg u32 a0, reg u32 a1, reg u32 gamma2) -> reg u32
     inline bool lt eq;
 
     res = 1;
-    #[declassify] a0 = a0;
+    () = #declassify(a0);
     if (a0 <=s gamma2) {
         mgamma2 = -gamma2;
 
@@ -111,7 +111,7 @@ inline fn __make_hint(reg u32 a0, reg u32 a1, reg u32 gamma2) -> reg u32
                 res = 0;
             }
 
-            #[declassify] a1 = a1;
+            () = #declassify(a1);
             if (a1 == 0) {
                 res = 0;
             }

--- a/arm-m4/ref/ml_dsa_65/ml_dsa.jazz
+++ b/arm-m4/ref/ml_dsa_65/ml_dsa.jazz
@@ -38,7 +38,7 @@ export fn ml_dsa_65_keygen(
 {
     verification_key, signing_key = _crypto_sign_keypair_seed(verification_key, signing_key, seed);
 
-    #[declassify] verification_key = verification_key;
+    () = #declassify(verification_key);
 
     return verification_key, signing_key;
 }

--- a/arm-m4/ref/ml_dsa_65/rej_eta.jinc
+++ b/arm-m4/ref/ml_dsa_65/rej_eta.jinc
@@ -4,7 +4,7 @@ inline fn rej_eta(
         reg u32 t
         ) -> reg ptr u32[N], reg u32
 {
-    #[declassify] t = t;
+    () = #declassify(t);
     if (t < 9) {
         a[ctr] = __imm_sub_reg(4, t);
         ctr += 1;

--- a/arm-m4/ref/ml_dsa_65/rounding.jinc
+++ b/arm-m4/ref/ml_dsa_65/rounding.jinc
@@ -93,7 +93,7 @@ inline fn __make_hint(reg u32 a0, reg u32 a1, reg u32 gamma2) -> reg u32
    inline bool lt eq;
 
    res = 1;
-   #[declassify] a0 = a0;
+   () = #declassify(a0);
    if (a0 <=s gamma2) {
      mgamma2 = -gamma2;
 
@@ -105,7 +105,7 @@ inline fn __make_hint(reg u32 a0, reg u32 a1, reg u32 gamma2) -> reg u32
          res = 0;
       }
 
-      #[declassify] a1 = a1;
+      () = #declassify(a1);
       if (a1 == 0) {
          res = 0;
        }

--- a/arm-m4/ref/ml_dsa_87/ml_dsa.jazz
+++ b/arm-m4/ref/ml_dsa_87/ml_dsa.jazz
@@ -38,7 +38,7 @@ export fn ml_dsa_87_keygen(
 {
     verification_key, signing_key = _crypto_sign_keypair_seed(verification_key, signing_key, seed);
 
-    #[declassify] verification_key = verification_key;
+    () = #declassify(verification_key);
 
     return verification_key, signing_key;
 }

--- a/arm-m4/ref/ml_dsa_87/rej_eta.jinc
+++ b/arm-m4/ref/ml_dsa_87/rej_eta.jinc
@@ -4,7 +4,7 @@ inline fn rej_eta(
         reg u32 t
 ) -> reg ptr u32[N], reg u32 
 {
-    #[declassify] t = t;
+    () = #declassify(t);
     reg u32 n205 = 205;
     if (t < 15) {
         reg u32 aux;

--- a/arm-m4/ref/ml_dsa_87/rounding.jinc
+++ b/arm-m4/ref/ml_dsa_87/rounding.jinc
@@ -45,7 +45,7 @@ inline fn __make_hint(reg u32 a0, reg u32 a1, reg u32 gamma2) -> reg u32
 
     res = 1;
 
-    #[declassify] a0 = a0;
+    () = #declassify(a0);
     if (a0 <=s gamma2) {
         mgamma2 = -gamma2;
 
@@ -57,7 +57,7 @@ inline fn __make_hint(reg u32 a0, reg u32 a1, reg u32 gamma2) -> reg u32
                 res = 0;
             }
 
-            #[declassify] a1 = a1;
+            () = #declassify(a1);
             if (a1 == 0) {
                 res = 0;
             }

--- a/x86-64/avx2/common/arithmetic/rounding.jinc
+++ b/x86-64/avx2/common/arithmetic/rounding.jinc
@@ -43,7 +43,7 @@ namespace polynomial {
             );
 
             // TODO: We could also handle serializing the hint here.
-            #[declassify] hint_block = hint_block;
+            () = #declassify(hint_block);
             num_hints = (64u)#MOVEMASK_8u32(hint_block);
             _, _, _, _, _, num_hints = #POPCNT_64(num_hints);
 

--- a/x86-64/avx2/common/keygen.jinc
+++ b/x86-64/avx2/common/keygen.jinc
@@ -111,7 +111,8 @@ fn __keygen_internal(
     state = __initialize_xof(randomness, ROWS_IN_MATRIX_A, COLUMNS_IN_MATRIX_A);
     prf_output = squeeze_128_bytes(prf_output, state);
 
-    #[declassify] seed_for_matrix_A = prf_output[:u8 0:SEED_FOR_MATRIX_A_SIZE];
+    seed_for_matrix_A = prf_output[:u8 0:SEED_FOR_MATRIX_A_SIZE];
+    () = #declassify(seed_for_matrix_A);
     matrix_A = sample::__matrix_A(seed_for_matrix_A);
 
     seed_for_error_vectors = prf_output[:u8 SEED_FOR_MATRIX_A_SIZE:SEED_FOR_ERROR_VECTORS_SIZE];
@@ -154,7 +155,7 @@ fn __keygen_internal(
 
     verification_key[32: T1_ENCODED_SIZE]
         = t1::__encode(verification_key[32: T1_ENCODED_SIZE], t1);
-    #[declassify] verification_key = verification_key;
+    () = #declassify(verification_key);
 
     // ... and finish serializing the signing key.
     verification_key_pointer_copy = verification_key;

--- a/x86-64/avx2/common/polynomial.jinc
+++ b/x86-64/avx2/common/polynomial.jinc
@@ -120,7 +120,7 @@ namespace polynomial {
         }
 
         // It is okay to leak which coefficient(s) violates the bound.
-        #[declassify] exceeds_any = exceeds_any;
+        () = #declassify(exceeds_any);
         msb_mask = #MOVEMASK_8u32(exceeds_any);
 
         _, _, _, _, zf = #TEST_32(msb_mask, msb_mask);

--- a/x86-64/avx2/common/sample/challenge.jinc
+++ b/x86-64/avx2/common/sample/challenge.jinc
@@ -71,7 +71,8 @@ namespace sample {
                     xof_block = shake256_squeeze_block(xof_block, state);
                     xof_offset = 0;
                 }
-                #[declassify] sample_at = (64u) xof_block[xof_offset];
+                sample_at = (64u) xof_block[xof_offset];
+                () = #declassify(sample_at);
 
                 xof_offset += 1;
             } (sample_at > i)

--- a/x86-64/avx2/common/sign.jinc
+++ b/x86-64/avx2/common/sign.jinc
@@ -119,7 +119,8 @@ fn __sign_internal(
     inline int i;
 
     () = #spill(signature, randomness, signing_key);
-    #[declassify] seed_for_matrix_A = signing_key[0:32];
+    seed_for_matrix_A = signing_key[0:32];
+    () = #declassify(seed_for_matrix_A);
     matrix_A = sample::__matrix_A(seed_for_matrix_A);
 
     () = #unspill(signing_key);
@@ -174,12 +175,12 @@ fn __sign_internal(
         w = column_vector::invert_ntt_montgomery(w);
 
         w = column_vector::__conditionally_add_modulus(w);
-        #[declassify] w0, w1 = column_vector::__decompose(w);
+        w0, w1 = column_vector::__decompose(w);
 
         commitment_encoded = commitment::__encode(w1);
 
         () = #spill(domain_separator_for_mask);
-        #[declassify] commitment_hash = __derive_commitment_hash(message_representative, commitment_encoded);
+        commitment_hash = __derive_commitment_hash(message_representative, commitment_encoded);
 
         verifier_challenge = sample::__challenge(verifier_challenge, commitment_hash);
         () = #unspill(domain_separator_for_mask);
@@ -188,7 +189,7 @@ fn __sign_internal(
 
         infinity_norm_check_result = 0;
         for i = 0 to COLUMNS_IN_MATRIX_A {
-            #[declassify] infinity_norm_check_result = infinity_norm_check_result;
+            () = #declassify(infinity_norm_check_result);
             if (infinity_norm_check_result == 0) {
                 signer_response[i * COEFFICIENTS_IN_POLYNOMIAL : COEFFICIENTS_IN_POLYNOMIAL] =
                     __compute_signer_response_element(
@@ -208,7 +209,7 @@ fn __sign_internal(
         total_ones_in_hint = 0;
         hint_elements_processed = 0;
         for i = 0 to ROWS_IN_MATRIX_A {
-            #[declassify] infinity_norm_check_result = infinity_norm_check_result;
+            () = #declassify(infinity_norm_check_result);
             if (infinity_norm_check_result == 0) {
                 s2_element = s2[i * COEFFICIENTS_IN_POLYNOMIAL : COEFFICIENTS_IN_POLYNOMIAL];
                 cs2 = polynomial::pointwise_montgomery_multiply_and_reduce(cs2, s2_element, verifier_challenge);
@@ -224,7 +225,7 @@ fn __sign_internal(
                 w0_minus_cs2 = polynomial::reduce32(w0_minus_cs2);
 
                 infinity_norm_check_result = polynomial::__check_infinity_norm(w0_minus_cs2, (int) (GAMMA2 - BETA));
-                #[declassify] infinity_norm_check_result = infinity_norm_check_result;
+                () = #declassify(infinity_norm_check_result);
 
                 if(infinity_norm_check_result == 0) {
                     t0_element = t0[i * COEFFICIENTS_IN_POLYNOMIAL : COEFFICIENTS_IN_POLYNOMIAL];
@@ -232,10 +233,10 @@ fn __sign_internal(
                     ct0 = polynomial::invert_ntt_montgomery(ct0);
                     ct0 = polynomial::reduce32(ct0);
                     infinity_norm_check_result = polynomial::__check_infinity_norm(ct0, GAMMA2);
-                    #[declassify] infinity_norm_check_result = infinity_norm_check_result;
+                    () = #declassify(infinity_norm_check_result);
 
                     if(infinity_norm_check_result == 0) {
-                        #[declassify] total_ones_in_hint = total_ones_in_hint;
+                        () = #declassify(total_ones_in_hint);
                         if (total_ones_in_hint <= MAX_ONES_IN_HINT) {
                             w0_minus_cs2_plus_ct0 = polynomial::add(w0_minus_cs2_plus_ct0, w0_minus_cs2, ct0);
                             hint_element = hint[i * COEFFICIENTS_IN_POLYNOMIAL : COEFFICIENTS_IN_POLYNOMIAL];
@@ -263,9 +264,9 @@ fn __sign_internal(
 
 
     () = #unspill(signature);
-    #[declassify] hint = hint;
-    #[declassify] commitment_hash = commitment_hash;
-    #[declassify] signer_response = signer_response;
+    () = #declassify(hint);
+    () = #declassify(commitment_hash);
+    () = #declassify(signer_response);
     signature = signature::__encode(signature, commitment_hash, signer_response, hint);
 
     return signature;

--- a/x86-64/avx2/common/verify.jinc
+++ b/x86-64/avx2/common/verify.jinc
@@ -24,7 +24,7 @@ fn __compare_commitment_hashes(reg ptr u8[COMMITMENT_HASH_SIZE] lhs rhs) -> reg 
     }
 
     result = (64u)#MOVEMASK_16u8(result_vec);
-    #[declassify] result = result;
+    () = #declassify(result);
 
     if (result == 0xFF_FF) {
         result = 0;
@@ -123,7 +123,8 @@ fn __verify_internal(
             A_times_signer_response = row_vector::__multiply_with_matrix_A(matrix_A, signer_response);
             () = #unspill(signature_encoded);
 
-            #[declassify] challenge = sample::__challenge(challenge, signature_encoded[0:COMMITMENT_HASH_SIZE]);
+            challenge = sample::__challenge(challenge, signature_encoded[0:COMMITMENT_HASH_SIZE]);
+            () = #declassify(challenge);
             challenge = polynomial::ntt(challenge);
 
             () = #unspill(verification_key);
@@ -144,7 +145,8 @@ fn __verify_internal(
                 context_message_sizes
             );
 
-            #[declassify] expected_commitment_hash = __derive_commitment_hash(message_representative, reconstructed_signer_commitment);
+            expected_commitment_hash = __derive_commitment_hash(message_representative, reconstructed_signer_commitment);
+            () = #declassify(expected_commitment_hash);
 
             () = #unspill(signature_encoded);
             result = __compare_commitment_hashes(expected_commitment_hash, signature_encoded[0:COMMITMENT_HASH_SIZE]);

--- a/x86-64/avx2/ml_dsa_44/sample/error_vectors/rejection_sample.jinc
+++ b/x86-64/avx2/ml_dsa_44/sample/error_vectors/rejection_sample.jinc
@@ -80,9 +80,10 @@ write_out_8_coefficients(
     return error, bytes_filled, good_overall;
 }
 
+#[ct = "_ × secret → _ × _"]
 fn rejection_sample_multiple_blocks(
     #[spill_to_mmx] reg ptr u32[COEFFICIENTS_IN_POLYNOMIAL] error,
-    #[secret] reg ptr u8[REJECTION_SAMPLING_BYTES] randombytes
+    reg ptr u8[REJECTION_SAMPLING_BYTES] randombytes
 ) -> reg ptr u32[COEFFICIENTS_IN_POLYNOMIAL], reg u64
 {
     reg u128 bytestream;
@@ -128,7 +129,7 @@ fn rejection_sample_multiple_blocks(
         coefficient_block = #VEXTRACTI128(coefficients, 0);
 
         // Start with the first 8
-        #[declassify] good_overall = good_overall;
+        () = #declassify(good_overall);
         error, bytes_filled, good_overall = write_out_8_coefficients(error, bytes_filled, good_overall, coefficient_block);
 
         xof_offset += 4;
@@ -174,7 +175,8 @@ fn rejection_sample_multiple_blocks(
 
     while (stop_sampling != 1) {
         coefficient = (32u)randombytes[xof_offset];
-        #[declassify] coefficient &= 0xF;
+        coefficient &= 0xF;
+        () = #declassify(coefficient);
 
         if (coefficient < 15) {
             temp_u32 = coefficient;
@@ -193,7 +195,8 @@ fn rejection_sample_multiple_blocks(
 
         if (filled < COEFFICIENTS_IN_POLYNOMIAL) {
             coefficient = (32u)randombytes[xof_offset];
-            #[declassify] coefficient >>= 4;
+            coefficient >>= 4;
+            () = #declassify(coefficient);
 
             if (coefficient < 15) {
                 temp_u32 = coefficient;
@@ -240,7 +243,8 @@ fn rejection_sample_one_block(
 
     while (stop_sampling != 1) {
         coefficient = (32u)randombytes[xof_offset];
-        #[declassify] coefficient &= 0xF;
+        coefficient &= 0xF;
+        () = #declassify(coefficient);
 
         if (coefficient < 15) {
             temp = coefficient;
@@ -259,7 +263,8 @@ fn rejection_sample_one_block(
 
         if (filled < COEFFICIENTS_IN_POLYNOMIAL) {
             coefficient = (32u)randombytes[xof_offset];
-            #[declassify] coefficient >>= 4;
+            coefficient >>= 4;
+            () = #declassify(coefficient);
 
             if (coefficient < 15) {
                 temp = coefficient;

--- a/x86-64/avx2/ml_dsa_65/sample/error_vectors/rejection_sample.jinc
+++ b/x86-64/avx2/ml_dsa_65/sample/error_vectors/rejection_sample.jinc
@@ -107,7 +107,7 @@ fn rejection_sample_multiple_blocks(
         coefficient_block = #VEXTRACTI128(coefficients, 0);
 
         // Start with the first 8
-        #[declassify] good_overall = good_overall;
+        () = #declassify(good_overall);
         error, bytes_filled, good_overall = __write_out_8_coefficients(error, bytes_filled, good_overall, coefficient_block);
 
         xof_offset += 4;
@@ -154,7 +154,8 @@ fn rejection_sample_multiple_blocks(
 
     while (stop_sampling != 1) {
         coefficient = (32u)randombytes[xof_offset];
-        #[declassify] coefficient &= 0xF;
+        coefficient &= 0xF;
+        () = #declassify(coefficient);
 
         if (coefficient < 9) {
             coefficient -= ETA;
@@ -166,7 +167,8 @@ fn rejection_sample_multiple_blocks(
 
         if (filled < COEFFICIENTS_IN_POLYNOMIAL) {
             coefficient = (32u)randombytes[xof_offset];
-            #[declassify] coefficient >>= 4;
+            coefficient >>= 4;
+            () = #declassify(coefficient);
 
             if (coefficient < 9) {
                 coefficient -= ETA;
@@ -205,7 +207,8 @@ fn rejection_sample_one_block(
 
     while (stop_sampling != 1) {
         coefficient = (32u)randombytes[xof_offset];
-        #[declassify] coefficient &= 0xF;
+        coefficient &= 0xF;
+        () = #declassify(coefficient);
 
         if (coefficient < 9) {
             coefficient -= ETA;
@@ -217,7 +220,8 @@ fn rejection_sample_one_block(
 
         if (filled < COEFFICIENTS_IN_POLYNOMIAL) {
             coefficient = (32u)randombytes[xof_offset];
-            #[declassify] coefficient >>= 4;
+            coefficient >>= 4;
+            () = #declassify(coefficient);
 
             if (coefficient < 9) {
                 coefficient -= ETA;

--- a/x86-64/avx2/ml_dsa_87/sample/error_vectors/rejection_sample.jinc
+++ b/x86-64/avx2/ml_dsa_87/sample/error_vectors/rejection_sample.jinc
@@ -80,9 +80,10 @@ __write_out_8_coefficients(
     return error, bytes_filled, good_overall;
 }
 
+#[ct = "_ * secret -> _ * _"]
 fn rejection_sample_multiple_blocks(
     #[spill_to_mmx] reg ptr u32[COEFFICIENTS_IN_POLYNOMIAL] error,
-    #[secret] reg ptr u8[REJECTION_SAMPLING_BYTES] randombytes
+    reg ptr u8[REJECTION_SAMPLING_BYTES] randombytes
 ) -> reg ptr u32[COEFFICIENTS_IN_POLYNOMIAL], reg u64
 {
     reg u128 bytestream;
@@ -128,7 +129,7 @@ fn rejection_sample_multiple_blocks(
         coefficient_block = #VEXTRACTI128(coefficients, 0);
 
         // Start with the first 8
-        #[declassify] good_overall = good_overall;
+        () = #declassify(good_overall);
         error, bytes_filled, good_overall = __write_out_8_coefficients(error, bytes_filled, good_overall, coefficient_block);
 
         xof_offset += 4;
@@ -175,7 +176,8 @@ fn rejection_sample_multiple_blocks(
 
     while (stop_sampling != 1) {
         coefficient = (32u)randombytes[xof_offset];
-        #[declassify] coefficient &= 0xF;
+        coefficient &= 0xF;
+        () = #declassify(coefficient);
 
         if (coefficient < 15) {
             temp_u32 = coefficient;
@@ -194,7 +196,8 @@ fn rejection_sample_multiple_blocks(
 
         if (filled < COEFFICIENTS_IN_POLYNOMIAL) {
             coefficient = (32u)randombytes[xof_offset];
-            #[declassify] coefficient >>= 4;
+            coefficient >>= 4;
+            () = #declassify(coefficient);
 
             if (coefficient < 15) {
                 temp_u32 = coefficient;
@@ -243,7 +246,8 @@ fn rejection_sample_one_block(
 
     while (stop_sampling != 1) {
         coefficient = (32u)randombytes[xof_offset];
-        #[declassify] coefficient &= 0xF;
+        coefficient &= 0xF;
+        () = #declassify(coefficient);
 
         if (coefficient < 15) {
             temp = coefficient;
@@ -262,7 +266,8 @@ fn rejection_sample_one_block(
 
         if (filled < COEFFICIENTS_IN_POLYNOMIAL) {
             coefficient = (32u)randombytes[xof_offset];
-            #[declassify] coefficient >>= 4;
+            coefficient >>= 4;
+            () = #declassify(coefficient);
 
             if (coefficient < 15) {
                 temp = coefficient;

--- a/x86-64/ref/common/arithmetic/rounding.jinc
+++ b/x86-64/ref/common/arithmetic/rounding.jinc
@@ -26,11 +26,12 @@ namespace coefficient {
     inline
     fn __make_hint(reg u32 a0, reg u32 a1, reg u64 msf) -> reg u32, #[msf] reg u64 {
         reg u32 result;
-        inline bool condition;
+        reg bool condition;
 
         result = 0;
 
-        #[declassify] condition = a0 >s GAMMA2;
+        condition = a0 >s GAMMA2;
+        () = #declassify(condition);
         if (condition) {
             msf = #update_msf(condition, msf);
 
@@ -38,18 +39,21 @@ namespace coefficient {
         } else {
             msf = #update_msf(!condition, msf);
 
-            #[declassify] condition = a0 <s -GAMMA2;
+            condition = a0 <s -GAMMA2;
+            () = #declassify(condition);
             if (condition) {
                 msf = #update_msf(condition, msf);
                 result = 1;
             } else {
                 msf = #update_msf(!condition, msf);
 
-                #[declassify] condition = a0 == -GAMMA2;
+                condition = a0 == -GAMMA2;
+                () = #declassify(condition);
                 if (condition) {
                     msf = #update_msf(condition, msf);
 
-                    #[declassify] condition = a1 != 0;
+                    condition = a1 != 0;
+                    () = #declassify(condition);
                     if (condition) {
                         msf = #update_msf(condition, msf);
                         result = 1;

--- a/x86-64/ref/common/keygen.jinc
+++ b/x86-64/ref/common/keygen.jinc
@@ -65,7 +65,8 @@ fn __keygen_internal(
     state = __prepare_state_for_shake256(randomness, ROWS_IN_MATRIX_A, COLUMNS_IN_MATRIX_A);
     state = _keccakf1600_ref1(state);
 
-    #[declassify] seed_for_matrix_A = state[:u8 0:SEED_FOR_MATRIX_A_SIZE];
+    seed_for_matrix_A = state[:u8 0:SEED_FOR_MATRIX_A_SIZE];
+    () = #declassify(seed_for_matrix_A);
 
     seed_for_error_vectors = state[:u8 SEED_FOR_MATRIX_A_SIZE:SEED_FOR_ERROR_VECTORS_SIZE];
     seed_for_signing = state[:u8 SEED_FOR_MATRIX_A_SIZE + SEED_FOR_ERROR_VECTORS_SIZE:SEED_FOR_SIGNING_SIZE];
@@ -119,8 +120,9 @@ fn __keygen_internal(
         i += 1;
     }
 
-    #[declassify] verification_key[32: T1_ENCODED_SIZE]
+    verification_key[32: T1_ENCODED_SIZE]
     = t1::__encode(verification_key[32: T1_ENCODED_SIZE], t1);
+    #declassify(verification_key);
 
     // ... and finish serializing the signing key.
     verification_key_pointer_copy = verification_key;

--- a/x86-64/ref/common/sample/challenge.jinc
+++ b/x86-64/ref/common/sample/challenge.jinc
@@ -68,7 +68,8 @@ namespace sample {
 
                     xof_offset = 0;
                 }
-                #[declassify] sample_at = (64u) state[:u8 xof_offset];
+                sample_at = (64u) state[:u8 xof_offset];
+                () = #declassify(sample_at);
                 _ = #init_msf();
 
                 xof_offset += 1;

--- a/x86-64/ref/common/sample/matrix_A.jinc
+++ b/x86-64/ref/common/sample/matrix_A.jinc
@@ -53,7 +53,8 @@ fn rejection_sample_less_than_field_modulus(
 
             try_coefficient = 0;
             for k = 0 to 3 {
-                #[declassify] byte = (32u)state[:u8 xof_offset + k];
+                byte = (32u)state[:u8 xof_offset + k];
+                () = #declassify(byte);
 
                 byte <<= 8 * k;
                 try_coefficient |= byte;

--- a/x86-64/ref/common/sign.jinc
+++ b/x86-64/ref/common/sign.jinc
@@ -80,7 +80,8 @@ fn __sign_internal(
         context_message_sizes);
 
     () = #unspill(signing_key);
-    #[declassify] seed_for_matrix_A = signing_key[0:32];
+    seed_for_matrix_A = signing_key[0:32];
+    () = #declassify(seed_for_matrix_A);
 
     _ = #init_msf();
     matrix_A = sample::__matrix_A(seed_for_matrix_A);
@@ -121,7 +122,8 @@ fn __sign_internal(
         w = column_vector::invert_ntt_montgomery(w);
 
         w = column_vector::__conditionally_add_modulus(w);
-        #[declassify] w0, w1 = column_vector::__decompose(w);
+        w0, w1 = column_vector::__decompose(w);
+        #declassify(w1);
 
         commitment_encoded = commitment::__encode(w1);
 
@@ -138,7 +140,7 @@ fn __sign_internal(
         signer_response = row_vector::__add(cs1, mask);
         signer_response = row_vector::reduce32(signer_response);
         infinity_norm_check_result = row_vector::__check_infinity_norm(signer_response, (int) (GAMMA1 - BETA));
-        #[declassify] infinity_norm_check_result = infinity_norm_check_result;
+        () = #declassify(infinity_norm_check_result);
 
         _ = #init_msf();
 
@@ -148,7 +150,7 @@ fn __sign_internal(
             w0_minus_cs2 = column_vector::__subtract(w0, cs2);
             w0_minus_cs2 = column_vector::reduce32(w0_minus_cs2);
             infinity_norm_check_result = column_vector::__check_infinity_norm(w0_minus_cs2, (int) (GAMMA2 - BETA));
-            #[declassify] infinity_norm_check_result = infinity_norm_check_result;
+            () = #declassify(infinity_norm_check_result);
 
             _ = #init_msf();
 
@@ -157,11 +159,12 @@ fn __sign_internal(
                 ct0 = column_vector::invert_ntt_montgomery(ct0);
                 ct0 = column_vector::reduce32(ct0);
                 infinity_norm_check_result = column_vector::__check_infinity_norm(ct0, GAMMA2);
-                #[declassify] infinity_norm_check_result = infinity_norm_check_result;
+                () = #declassify(infinity_norm_check_result);
 
                 _ = #init_msf();
                 if(infinity_norm_check_result == 0) {
-                    #[declassify] w0_minus_cs2_plus_ct0 = column_vector::__add(w0_minus_cs2, ct0);
+                    w0_minus_cs2_plus_ct0 = column_vector::__add(w0_minus_cs2, ct0);
+                    #declassify(w0_minus_cs2_plus_ct0);
 
                     hint, ones_in_hint = column_vector::__make_hint(w0_minus_cs2_plus_ct0, w1);
 
@@ -176,9 +179,9 @@ fn __sign_internal(
 
     () = #unspill(signature);
 
-    #[declassify] signer_response = signer_response;
-    #[declassify] hint = hint;
-    #[declassify] commitment_hash = commitment_hash;
+    () = #declassify(signer_response);
+    () = #declassify(hint);
+    () = #declassify(commitment_hash);
     signature = signature::__encode(signature, commitment_hash, signer_response, hint);
     return signature;
 }

--- a/x86-64/ref/common/verify.jinc
+++ b/x86-64/ref/common/verify.jinc
@@ -21,7 +21,7 @@ fn __compare_commitment_hashes(reg ptr u8[COMMITMENT_HASH_SIZE] lhs rhs) -> reg 
         rhs_byte = rhs[i];
         rhs_byte = #protect_8(rhs_byte, msf);
 
-        #[declassify] condition = lhs_byte != rhs_byte;
+        condition = lhs_byte != rhs_byte;
         if (condition) {
             msf = #update_msf(condition, msf);
             result |= (64u)-1;
@@ -73,7 +73,7 @@ fn reconstruct_signer_commitment(
         commitment_element = polynomial::conditionally_add_modulus(commitment_element);
 
 
-        #[declassify] commitment_element = commitment_element;
+        () = #declassify(commitment_element);
         commitment_element = polynomial::use_hints(
             commitment_element,
             hints[i * COEFFICIENTS_IN_POLYNOMIAL : COEFFICIENTS_IN_POLYNOMIAL]);
@@ -114,10 +114,12 @@ fn __verify_internal(
 
     signer_response = gamma1::__decode(signer_response, signature_encoded[COMMITMENT_HASH_SIZE: GAMMA1_ENCODED_SIZE]);
 
-    #[declassify] signer_response_outside_bounds = row_vector::__check_infinity_norm(signer_response, (int) (GAMMA1 - BETA));
+    signer_response_outside_bounds = row_vector::__check_infinity_norm(signer_response, (int) (GAMMA1 - BETA));
+    () = #declassify(signer_response_outside_bounds);
     _ = #init_msf();
     if (signer_response_outside_bounds == 0) {
-        #[declassify] hints, result = signature::__decode_hint(hints, signature_encoded[signature::START_OF_HINT:HINT_ENCODED_SIZE]);
+        hints, result = signature::__decode_hint(hints, signature_encoded[signature::START_OF_HINT:HINT_ENCODED_SIZE]);
+        #declassify(hints);
 
         if (result == 0) {
             () = #spill(context_message_pointers, context_message_sizes);
@@ -129,7 +131,8 @@ fn __verify_internal(
             A_times_signer_response = row_vector::__multiply_with_matrix_A(matrix_A, signer_response);
             () = #unspill(signature_encoded);
 
-            #[declassify] challenge = sample::__challenge(challenge, signature_encoded[0:COMMITMENT_HASH_SIZE]);
+            challenge = sample::__challenge(challenge, signature_encoded[0:COMMITMENT_HASH_SIZE]);
+            () = #declassify(challenge);
             challenge = polynomial::ntt(challenge);
 
             () = #unspill(verification_key);
@@ -149,7 +152,8 @@ fn __verify_internal(
                 context_message_pointers,
                 context_message_sizes);
 
-            #[declassify] expected_commitment_hash = __derive_commitment_hash(message_representative, reconstructed_signer_commitment);
+            expected_commitment_hash = __derive_commitment_hash(message_representative, reconstructed_signer_commitment);
+            () = #declassify(expected_commitment_hash);
 
             () = #unspill(signature_encoded);
             result = __compare_commitment_hashes(expected_commitment_hash, signature_encoded[0:COMMITMENT_HASH_SIZE]);

--- a/x86-64/ref/ml_dsa_44/sample/error_vectors.jinc
+++ b/x86-64/ref/ml_dsa_44/sample/error_vectors.jinc
@@ -56,7 +56,8 @@ fn rejection_sample_less_than_eta(
 
             byte = state[:u8 xof_offset];
 
-            #[declassify] coefficient = (32u)byte;
+            coefficient = (32u)byte;
+            () = #declassify(coefficient);
             coefficient &= 0x0F;
 
             coefficient = #protect_32(coefficient, msf);
@@ -85,7 +86,8 @@ fn rejection_sample_less_than_eta(
             if (b) {
                 msf = #update_msf(b, msf);
 
-                #[declassify] coefficient = (32u)byte;
+                coefficient = (32u)byte;
+                () = #declassify(coefficient);
                 coefficient >>= 4;
                 coefficient = #protect_32(coefficient, msf);
 

--- a/x86-64/ref/ml_dsa_65/sample/error_vectors.jinc
+++ b/x86-64/ref/ml_dsa_65/sample/error_vectors.jinc
@@ -54,7 +54,8 @@ fn rejection_sample_less_than_eta(
 
             byte = state[:u8 xof_offset];
 
-            #[declassify] try_coefficient = (32u)byte;
+            try_coefficient = (32u)byte;
+            () = #declassify(try_coefficient);
             try_coefficient &= 0x0F;
 
             try_coefficient = #protect_32(try_coefficient, msf);
@@ -76,7 +77,8 @@ fn rejection_sample_less_than_eta(
             if (b) {
                 msf = #update_msf(b, msf);
 
-                #[declassify] try_coefficient = (32u)byte;
+                try_coefficient = (32u)byte;
+                () = #declassify(try_coefficient);
                 try_coefficient >>= 4;
                 try_coefficient = #protect_32(try_coefficient, msf);
 

--- a/x86-64/ref/ml_dsa_87/sample/error_vectors.jinc
+++ b/x86-64/ref/ml_dsa_87/sample/error_vectors.jinc
@@ -56,7 +56,8 @@ fn rejection_sample_less_than_eta(
 
             byte = state[:u8 xof_offset];
 
-            #[declassify] coefficient = (32u)byte;
+            coefficient = (32u)byte;
+            () = #declassify(coefficient);
             coefficient &= 0x0F;
 
             coefficient = #protect_32(coefficient, msf);
@@ -85,7 +86,8 @@ fn rejection_sample_less_than_eta(
             if (b) {
                 msf = #update_msf(b, msf);
 
-                #[declassify] coefficient = (32u)byte;
+                coefficient = (32u)byte;
+                () = #declassify(coefficient);
                 coefficient >>= 4;
                 coefficient = #protect_32(coefficient, msf);
 


### PR DESCRIPTION
The use of a `declassify` annotation on assignments is deprecated.