### PR TITLE
lowram: do not call __add_block_end with non-inline argument

### DIFF
--- a/arm-m4/lowram/common/hashing.jinc
+++ b/arm-m4/lowram/common/hashing.jinc
@@ -312,7 +312,8 @@ fn _hash_verification_key(
         state_offset += 1;
     }
 
-    state = __add_block_end(state, state_offset * 4, SHAKE256_RATE);
+    state_offset <<= 2;
+    state = _shake256_add_block_end(state, state_offset);
     state = _keccakf1600_ref(state);
 
     return state;


### PR DESCRIPTION
The `__add_block_end` inline function expects an inline value as second argument (i.e., a value that the compiler can figure out at compile-time).

It is unexpected that the compiler successfully accepts this program.